### PR TITLE
release v0.1.4

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -32,5 +32,6 @@ jobs:
           printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
           gem build *.gemspec
           gem push *.gem
+        continue-on-error: true
         env:
           GEM_HOST_API_KEY: ${{secrets.RUBYGEMS_AUTH_TOKEN}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 0.1.4
+
+- rename module 'Omniauth' to 'OmniAuth'.
+- make callback_url method private method.
+- update gem-push GitHub Actions settings in order to ignore error for same version.
+
+# 0.1.3
+
+- update README.
+
 # 0.1.2
 
 - refs #1 setup GitHub Actions for rspec and pushing to RubyGems.

--- a/lib/omniauth-cybozu/version.rb
+++ b/lib/omniauth-cybozu/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-module Omniauth
+module OmniAuth
   module Cybozu
-    VERSION = '0.1.3'
+    VERSION = '0.1.4'
   end
 end

--- a/lib/omniauth/strategies/cybozu.rb
+++ b/lib/omniauth/strategies/cybozu.rb
@@ -12,6 +12,8 @@ module OmniAuth
       option :client_options, :authorize_url => '/oauth2/authorization',
                :token_url => '/oauth2/token'
 
+    private
+
       def callback_url
         full_host + script_name + callback_path
       end

--- a/omniauth-cybozu.gemspec
+++ b/omniauth-cybozu.gemspec
@@ -4,7 +4,7 @@ require_relative 'lib/omniauth-cybozu/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'omniauth-cybozu'
-  spec.version       = Omniauth::Cybozu::VERSION
+  spec.version       = OmniAuth::Cybozu::VERSION
   spec.authors       = ['Kenji Koshikawa']
   spec.email         = ['koshikawa2009@gmail.com']
 

--- a/spec/omniauth/strategies/cybozu_spec.rb
+++ b/spec/omniauth/strategies/cybozu_spec.rb
@@ -25,7 +25,7 @@ describe OmniAuth::Strategies::Cybozu do
     it 'returns callback url' do
       allow(subject).to receive(:full_host) { 'http://localhost' }
       allow(subject).to receive(:script_name) { '/v1' }
-      expect(subject.callback_url).to eq 'http://localhost/v1/auth/cybozu/callback'
+      expect(subject.send(:callback_url)).to eq 'http://localhost/v1/auth/cybozu/callback'
     end
   end
 end


### PR DESCRIPTION
- rename module 'Omniauth' to 'OmniAuth'.
- make callback_url method private method.
- update gem-push GitHub Actions settings in order to ignore error for same version.
